### PR TITLE
Integrate codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea
 *.iml
+
+*.cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ install:
 
 script:
   - gometalinter --config=.gometalinter.json ./...
-  - go test -race -cover ./
+  - go test -race -coverprofile=all.cov -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -f all.cov
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ envigo [![GitHub release](https://img.shields.io/github/release/tyranron/envigo.
 
 [![Build Status](https://travis-ci.org/tyranron/envigo.svg?branch=master)](https://travis-ci.org/tyranron/envigo)
 [![GoCover](https://gocover.io/_badge/github.com/tyranron/envigo)](https://gocover.io/github.com/tyranron/envigo)
+[![Codecov](https://codecov.io/gh/tyranron/envigo/branch/master/graph/badge.svg)](https://codecov.io/gh/tyranron/envigo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tyranron/envigo)](https://goreportcard.com/report/github.com/tyranron/envigo)
 [![GoDoc](https://godoc.org/github.com/tyranron/envigo?status.svg)](https://godoc.org/github.com/tyranron/envigo)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](#license)


### PR DESCRIPTION
Integrates [codecov.io](https://codecov.io) for code coverage in addition to gocover.io.